### PR TITLE
added makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PKGS := $(shell go list ./... | grep -v /vendor)
 
 .PHONY: test
-test: lint
+test:
 	go test $(PKGS)
 
 BIN_DIR := $(GOPATH)/bin

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,15 @@ GOBIN=$(GOBASE)/bin
 BIN_DIR := $(GOPATH)/bin
 GOMETALINTER := $(BIN_DIR)/gometalinter
 
+.PHONY: help
+all: help
+help: Makefile
+	@echo
+	@echo " Choose a make command to run in "$(PROJECTNAME)":"
+	@echo
+	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
+	@echo
+
 ## test: Runs `go test` on project test files.
 .PHONY: test
 test:
@@ -19,7 +28,7 @@ $(GOMETALINTER):
 ## lint: Lints project files, go gets gometalinter if missing. Runs `gometalinter` on project files.
 .PHONY: lint
 lint: $(GOMETALINTER)
-	gometalinter ./... exclude=gosec --vendor
+	gometalinter ./... --vendor
 
 ## install: Install missing dependencies. Runs `go get` internally.
 install:
@@ -30,12 +39,3 @@ install:
 clean:
 	@echo "  >  \033[32mCleaning build cache...\033[0m "
 	@GOPATH=$(GOPATH) GOBIN=$(GOBIN) go clean
-
-.PHONY: help
-all: help
-help: Makefile
-	@echo
-	@echo " Choose a make command to run in "$(PROJECTNAME)":"
-	@echo
-	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
-	@echo

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,41 @@
 PKGS := $(shell go list ./... | grep -v /vendor)
 
-.PHONY: test
-test:
-	go test $(PKGS)
+PROJECTNAME=$(shell basename "$(PWD)")
+GOBASE=$(shell pwd)
+GOBIN=$(GOBASE)/bin
 
 BIN_DIR := $(GOPATH)/bin
 GOMETALINTER := $(BIN_DIR)/gometalinter
+
+## test: Runs `go test` on project test files.
+.PHONY: test
+test:
+	go test $(PKGS)
 
 $(GOMETALINTER):
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install &> /dev/null
 
+## lint: Lints project files, go gets gometalinter if missing. Runs `gometalinter` on project files.
 .PHONY: lint
 lint: $(GOMETALINTER)
 	gometalinter ./... exclude=gosec --vendor
 
+## install: Install missing dependencies. Runs `go get` internally.
 install:
 	@echo "  >  \033[32mInstalling dependencies...\033[0m "
-	go mod vendor
+	@GOPATH=$(GOPATH) GOBIN=$(GOBIN) go get $(get)
+
+## clean: Clean build files. Runs `go clean` internally.
+clean:
+	@echo "  >  \033[32mCleaning build cache...\033[0m "
+	@GOPATH=$(GOPATH) GOBIN=$(GOBIN) go clean
+
+.PHONY: help
+all: help
+help: Makefile
+	@echo
+	@echo " Choose a make command to run in "$(PROJECTNAME)":"
+	@echo
+	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
+	@echo

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+PKGS := $(shell go list ./... | grep -v /vendor)
+
+.PHONY: test
+test: lint
+	go test $(PKGS)
+
+BIN_DIR := $(GOPATH)/bin
+GOMETALINTER := $(BIN_DIR)/gometalinter
+
+$(GOMETALINTER):
+	go get -u github.com/alecthomas/gometalinter
+	gometalinter --install &> /dev/null
+
+.PHONY: lint
+lint: $(GOMETALINTER)
+	gometalinter ./... exclude=gosec --vendor
+
+install:
+	@echo "  >  \033[32mInstalling dependencies...\033[0m "
+	go mod vendor

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,0 @@
-module go-pre


### PR DESCRIPTION
**Changes made in this pull request:**

- added Makefile with the following commands:
        - **make help**: this will outline all possible commands within makefile
        - **make lint** : this uses `gometalinter` and will `go get` the package if it's not present
        - **make test** : this will run the `go test ./...` command
        - **make install** : this will install dependencies
        - **make clean** : this will clean build cache


Since we don't have any go files present, these will return an error.

The rationale for the makefile is to be able to use common commands with general ease. Moving forward the Makefile will be primarily used for different builds much like its used in `go-ethereum`.

 [Here](https://azer.bike/journal/a-good-makefile-for-go/) is a good link for an overview of a makefile in go