### PR TITLE
Elizabeth/scale tuples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # VS Code
 .vscode
+
+# Sublime
+*.sublime*

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,5 @@
 
 # Sublime
 *.sublime*
-<<<<<<< HEAD
-=======
 
 go-pre.db
->>>>>>> 002409e6d37814f531a2a8ff5337b30d81d72e05

--- a/codec/decode.go
+++ b/codec/decode.go
@@ -54,8 +54,7 @@ func DecodeInteger(b []byte) (o int64, bytesDecoded int64, err error) {
 
 // DecodeByteArray accepts a byte array representing a SCALE encoded byte array and performs SCALE decoding
 // of the byte array
-// if the encoding is valid, it then returns (o, bytesDecoded, err) where o is the decoded byte array, bytesDecoded is
-// the number of input bytes decoded, and err is nil
+// if the encoding is valid, it then returns the decoded byte array, the total number of input bytes decoded, and nil
 // otherwise, it returns nil, 0, and error
 func DecodeByteArray(b []byte) (o []byte, bytesDecoded int64, err error) {
 	var length int64
@@ -130,7 +129,7 @@ func DecodeBool(b byte) (bool, error) {
 
 // DecodeTuple accepts a byte array representing the SCALE encoded tuple and an interface. This interface should be a pointer
 // to a struct which the encoded tuple should be marshalled into. If it is a valid encoding for the struct, it returns the
-// decoded struct and nil, otherwise return nil, err.
+// decoded struct, otherwise error,
 // Note that we return the same interface that was passed to this function; this is because we are writing directly to the
 // struct that is passed in, using reflect to get each of the fields.
 func DecodeTuple(b []byte, t interface{}) (interface{}, error) {

--- a/codec/decode.go
+++ b/codec/decode.go
@@ -7,7 +7,7 @@ import (
 )
 
 // DecodeInteger accepts a byte array representing a SCALE encoded integer and performs SCALE decoding of the int
-// if the encoding is valid, it then returns (o, bytesDecoded, err) where o is the decoded integer, bytesDecoded is the 
+// if the encoding is valid, it then returns (o, bytesDecoded, err) where o is the decoded integer, bytesDecoded is the
 // number of input bytes decoded, and err is nil
 // otherwise, it returns 0, 0, and error
 func DecodeInteger(b []byte) (o int64, bytesDecoded int64, err error) {
@@ -54,7 +54,7 @@ func DecodeInteger(b []byte) (o int64, bytesDecoded int64, err error) {
 
 // DecodeByteArray accepts a byte array representing a SCALE encoded byte array and performs SCALE decoding
 // of the byte array
-// if the encoding is valid, it then returns (o, bytesDecoded, err) where o is the decoded byte array, bytesDecoded is 
+// if the encoding is valid, it then returns (o, bytesDecoded, err) where o is the decoded byte array, bytesDecoded is
 // the number of input bytes decoded, and err is nil
 // otherwise, it returns nil, 0, and error
 func DecodeByteArray(b []byte) (o []byte, bytesDecoded int64, err error) {
@@ -128,13 +128,15 @@ func DecodeBool(b byte) (bool, error) {
 	return false, errors.New("cannot decode invalid boolean")
 }
 
-// DecodeTuple acceps a byte array representing the SCALE encoded tuple and an interface. This interface should be the 
-// struct which the encoded tuple shpuld be marshalled into. If it is a valid encoding for the struct, it returns the
+// DecodeTuple acceps a byte array representing the SCALE encoded tuple and an interface. This interface should be a pointer
+// to a struct which the encoded tuple shpuld be marshalled into. If it is a valid encoding for the struct, it returns the
 // decoded struct and nil, otherwise return nil, err.
+// Note that we return the same interface that was passed to this function; this is because we are writing directly to the
+// struct that is passed in, using reflect to get each of the fields.
 func DecodeTuple(b []byte, t interface{}) (interface{}, error) {
 	v := reflect.ValueOf(t).Elem()
 
-	var bytesDecoded int64 = 0
+	var bytesDecoded int64
 	var byteLen int64
 	var err error
 	var o interface{}

--- a/codec/decode.go
+++ b/codec/decode.go
@@ -7,7 +7,8 @@ import (
 )
 
 // DecodeInteger accepts a SCALE encoded integer and performs SCALE decoding of it
-// if the encoding is valid, it then returns the decoded integer and the total number of input bytes decoded
+// if the encoding is valid, it then returns the decoded integer and the total number of input bytes
+// used to create the decoded integer, including the mode/length byte
 // otherwise, it returns an error
 func DecodeInteger(b []byte) (o int64, bytesDecoded int64, err error) {
 	// check mode of encoding, stored at 2 least significant bits

--- a/codec/decode.go
+++ b/codec/decode.go
@@ -128,8 +128,8 @@ func DecodeBool(b byte) (bool, error) {
 	return false, errors.New("cannot decode invalid boolean")
 }
 
-// DecodeTuple acceps a byte array representing the SCALE encoded tuple and an interface. This interface should be a pointer
-// to a struct which the encoded tuple shpuld be marshalled into. If it is a valid encoding for the struct, it returns the
+// DecodeTuple accepts a byte array representing the SCALE encoded tuple and an interface. This interface should be a pointer
+// to a struct which the encoded tuple should be marshalled into. If it is a valid encoding for the struct, it returns the
 // decoded struct and nil, otherwise return nil, err.
 // Note that we return the same interface that was passed to this function; this is because we are writing directly to the
 // struct that is passed in, using reflect to get each of the fields.

--- a/codec/decode.go
+++ b/codec/decode.go
@@ -1,0 +1,148 @@
+package codec
+
+import (
+	"encoding/binary"
+	"errors"
+	"reflect"
+)
+
+// DecodeInteger accepts a byte array representing a SCALE encoded integer and performs SCALE decoding of the
+// int, then returns it
+func DecodeInteger(b []byte) (int64, error) {
+	mode := b[0] & 0x03
+	if mode == 0 {
+		return int64(b[0] >> 2), nil
+	} else if mode == 1 {
+		o := binary.LittleEndian.Uint16(b) >> 2
+		return int64(o), nil
+	} else if mode == 2 {
+		o := binary.LittleEndian.Uint32(b) >> 2
+		return int64(o), nil
+	}
+
+	var o int64
+	var err error
+
+	topSixBits := (binary.LittleEndian.Uint16(b) & 0xff) >> 2
+	byteLen := topSixBits + 4
+
+	if len(b) < int(byteLen) + 1 {
+		err = errors.New("could not decode invalid integer")
+	}
+
+	if err == nil {
+		if byteLen == 4 {
+			o = int64(binary.LittleEndian.Uint32(b[1 : byteLen+1]))
+		} else if byteLen > 4 && byteLen < 8 {
+			upperBytes := make([]byte, 8-byteLen)
+			upperBytes = append(b[5:byteLen+1], upperBytes...)
+			upper := int64(binary.LittleEndian.Uint32(upperBytes)) << 32
+			lower := int64(binary.LittleEndian.Uint32(b[1:5]))
+			o = upper + lower
+		}
+
+		if o == 0 {
+			err = errors.New("could not decode invalid integer")
+		}
+	}
+
+	return o, err
+}
+
+// DecodeByteArray accepts a byte array representing a SCALE encoded byte array and performs SCALE decoding
+// of the byte array, then returns it.  If it is invalid, return nil and error
+func DecodeByteArray(b []byte) ([]byte, error) {
+	var o []byte
+	var err error
+
+	mode := b[0] & 0x03
+	if mode == 0 { // encoding of length: 1 byte mode
+		length, err := DecodeInteger([]byte{b[0]})
+		if err == nil {
+			if length == 0 || length > 1<<6 || int64(len(b)) < length+1 {
+				err = errors.New("could not decode invalid byte array")
+			} else {
+				o = b[1 : length+1]
+			}
+		}
+	} else if mode == 1 { // encoding of length: 2 byte mode
+		// pass first two bytes of byte array to decode length
+		length, err := DecodeInteger(b[0:2])
+
+		if err == nil {
+			if length < 1<<6 || length > 1<<14 || int64(len(b)) < length+2 {
+				err = errors.New("could not decode invalid byte array")
+			} else {
+				o = b[2 : length+2]
+			}
+		}
+	} else if mode == 2 { // encoding of length: 4 byte mode
+		// pass first four bytes of byte array to decode length
+		length, err := DecodeInteger(b[0:4])
+
+		if err == nil {
+			if length < 1<<14 || length > 1<<30 || int64(len(b)) < length+4 {
+				err = errors.New("could not decode invalid byte array")
+			} else {
+				o = b[4 : length+4]
+			}
+		}
+	} else if mode == 3 { // encoding of length: big-integer mode
+		length, err := DecodeInteger(b)
+
+		if err == nil {
+			// get the length of the encoded length
+			topSixBits := (binary.LittleEndian.Uint16(b) & 0xff) >> 2
+			byteLen := topSixBits + 4
+
+			if length < 1<<30 || int64(len(b)) < (length+int64(byteLen))+1 {
+				err = errors.New("could not decode invalid byte array")
+			} else {
+				o = b[int64(byteLen)+1 : length+int64(byteLen)+1]
+			}
+		}
+	}
+
+	return o, err
+}
+
+// DecodeBool accepts a byte array representing a SCALE encoded bool and performs SCALE decoding
+// of the bool then returns it. if invalid, return false and an error
+func DecodeBool(b byte) (bool, error) {
+	if b == 1 {
+		return true, nil
+	} else if b == 0 {
+		return false, nil
+	}
+
+	return false, errors.New("cannot decode invalid boolean")
+}
+
+func DecodeTuple(b []byte, t interface{}) (interface{}, error) {
+	v := reflect.ValueOf(t)
+
+	output := make([]interface{}, v.NumField())
+	//bytesDecoded := 0
+
+	for i := 0; i < v.NumField(); i++ {
+		//fmt.Println(v.Field(i).Interface())
+		switch v.Field(i).Interface().(type) {
+		case []byte:
+			o, err := DecodeByteArray(b)
+			if err != nil {
+				return nil, err
+			}
+
+			output[i] = o
+		case int64:
+			o, err := DecodeInteger(b)
+			if err != nil {
+				return nil, err
+			}
+
+			output[i] = o
+		}
+	}
+
+	return output, nil
+}

--- a/codec/decode.go
+++ b/codec/decode.go
@@ -6,10 +6,9 @@ import (
 	"reflect"
 )
 
-// DecodeInteger accepts a byte array representing a SCALE encoded integer and performs SCALE decoding of the int
-// if the encoding is valid, it then returns (o, bytesDecoded, err) where o is the decoded integer, bytesDecoded is the
-// number of input bytes decoded, and err is nil
-// otherwise, it returns 0, 0, and error
+// DecodeInteger accepts a SCALE encoded integer and performs SCALE decoding of it
+// if the encoding is valid, it then returns the decoded integer and the total number of input bytes decoded
+// otherwise, it returns an error
 func DecodeInteger(b []byte) (o int64, bytesDecoded int64, err error) {
 	// check mode of encoding, stored at 2 least significant bits
 	mode := b[0] & 0x03
@@ -52,10 +51,9 @@ func DecodeInteger(b []byte) (o int64, bytesDecoded int64, err error) {
 	return o, bytesDecoded, err
 }
 
-// DecodeByteArray accepts a byte array representing a SCALE encoded byte array and performs SCALE decoding
-// of the byte array
-// if the encoding is valid, it then returns the decoded byte array, the total number of input bytes decoded, and nil
-// otherwise, it returns nil, 0, and error
+// DecodeByteArray accepts a SCALE encoded byte array and performs SCALE decoding of it
+// If the encoding is valid, it returns the decoded byte array, the total number of input bytes decoded including
+// the length bits and the byte array itself, and nil. Otherwise, it returns an error.
 func DecodeByteArray(b []byte) (o []byte, bytesDecoded int64, err error) {
 	var length int64
 

--- a/codec/decode.go
+++ b/codec/decode.go
@@ -8,21 +8,19 @@ import (
 
 // DecodeInteger accepts a byte array representing a SCALE encoded integer and performs SCALE decoding of the
 // int, then returns it
-func DecodeInteger(b []byte) (int64, error) {
+func DecodeInteger(b []byte) (o int64, bytesDecoded int64, err error) {
 	mode := b[0] & 0x03
-	if mode == 0 {
-		return int64(b[0] >> 2), nil
-	} else if mode == 1 {
+	if mode == 0 { // 1 byte mode
+		return int64(b[0] >> 2), 1, nil
+	} else if mode == 1 { // 2 byte mode
 		o := binary.LittleEndian.Uint16(b) >> 2
-		return int64(o), nil
-	} else if mode == 2 {
+		return int64(o), 2, nil
+	} else if mode == 2 { // 4 byte mode
 		o := binary.LittleEndian.Uint32(b) >> 2
-		return int64(o), nil
+		return int64(o), 4, nil
 	}
 
-	var o int64
-	var err error
-
+	// >4 byte mode
 	topSixBits := (binary.LittleEndian.Uint16(b) & 0xff) >> 2
 	byteLen := topSixBits + 4
 
@@ -31,11 +29,13 @@ func DecodeInteger(b []byte) (int64, error) {
 	}
 
 	if err == nil {
+		bytesDecoded = int64(byteLen) + 1
 		if byteLen == 4 {
-			o = int64(binary.LittleEndian.Uint32(b[1 : byteLen+1]))
+			o = int64(binary.LittleEndian.Uint32(b[1 : bytesDecoded]))
 		} else if byteLen > 4 && byteLen < 8 {
+			// need to pad upper bytes with zeros so that we can perform binary decoding
 			upperBytes := make([]byte, 8-byteLen)
-			upperBytes = append(b[5:byteLen+1], upperBytes...)
+			upperBytes = append(b[5:bytesDecoded], upperBytes...)
 			upper := int64(binary.LittleEndian.Uint32(upperBytes)) << 32
 			lower := int64(binary.LittleEndian.Uint32(b[1:5]))
 			o = upper + lower
@@ -46,49 +46,49 @@ func DecodeInteger(b []byte) (int64, error) {
 		}
 	}
 
-	return o, err
+	return o, bytesDecoded, err
 }
 
 // DecodeByteArray accepts a byte array representing a SCALE encoded byte array and performs SCALE decoding
 // of the byte array, then returns it.  If it is invalid, return nil and error
-func DecodeByteArray(b []byte) ([]byte, error) {
-	var o []byte
-	var err error
-
+func DecodeByteArray(b []byte) (o []byte, bytesDecoded int64, err error) {
 	mode := b[0] & 0x03
 	if mode == 0 { // encoding of length: 1 byte mode
-		length, err := DecodeInteger([]byte{b[0]})
+		length, _, err := DecodeInteger([]byte{b[0]})
 		if err == nil {
 			if length == 0 || length > 1<<6 || int64(len(b)) < length+1 {
 				err = errors.New("could not decode invalid byte array")
 			} else {
 				o = b[1 : length+1]
+				bytesDecoded = length + 1
 			}
 		}
 	} else if mode == 1 { // encoding of length: 2 byte mode
 		// pass first two bytes of byte array to decode length
-		length, err := DecodeInteger(b[0:2])
+		length, _, err := DecodeInteger(b[0:2])
 
 		if err == nil {
 			if length < 1<<6 || length > 1<<14 || int64(len(b)) < length+2 {
 				err = errors.New("could not decode invalid byte array")
 			} else {
 				o = b[2 : length+2]
+				bytesDecoded = length + 2
 			}
 		}
 	} else if mode == 2 { // encoding of length: 4 byte mode
 		// pass first four bytes of byte array to decode length
-		length, err := DecodeInteger(b[0:4])
+		length, _, err := DecodeInteger(b[0:4])
 
 		if err == nil {
 			if length < 1<<14 || length > 1<<30 || int64(len(b)) < length+4 {
 				err = errors.New("could not decode invalid byte array")
 			} else {
 				o = b[4 : length+4]
+				bytesDecoded = length + 4
 			}
 		}
 	} else if mode == 3 { // encoding of length: big-integer mode
-		length, err := DecodeInteger(b)
+		length, _, err := DecodeInteger(b)
 
 		if err == nil {
 			// get the length of the encoded length
@@ -99,11 +99,12 @@ func DecodeByteArray(b []byte) ([]byte, error) {
 				err = errors.New("could not decode invalid byte array")
 			} else {
 				o = b[int64(byteLen)+1 : length+int64(byteLen)+1]
+				bytesDecoded = int64(byteLen) + length + 1
 			}
 		}
 	}
 
-	return o, err
+	return o, bytesDecoded, err
 }
 
 // DecodeBool accepts a byte array representing a SCALE encoded bool and performs SCALE decoding
@@ -115,34 +116,47 @@ func DecodeBool(b byte) (bool, error) {
 		return false, nil
 	}
 
-	return false, errors.New("cannot decode invalid boolean")
+	return false, errors.New("cannot decode invalid boolean") 
 }
 
 func DecodeTuple(b []byte, t interface{}) (interface{}, error) {
-	v := reflect.ValueOf(t)
+	v := reflect.ValueOf(t).Elem()
+	
+	var bytesDecoded int64 = 0
+	var byteLen int64
+	var err error
+	var o interface{}
 
-	output := make([]interface{}, v.NumField())
-	//bytesDecoded := 0
+	val := reflect.Indirect(reflect.ValueOf(t))
 
+	// iterate through each field in the struct
 	for i := 0; i < v.NumField(); i++ {
-		//fmt.Println(v.Field(i).Interface())
+		// get the field value at i
+		fieldValue := val.Field(i)
+
 		switch v.Field(i).Interface().(type) {
 		case []byte:
-			o, err := DecodeByteArray(b)
+			o, byteLen, err = DecodeByteArray(b[bytesDecoded:])
 			if err != nil {
 				return nil, err
 			}
 
-			output[i] = o
+			// get the pointer to the value and set the value
+			ptr := fieldValue.Addr().Interface().(*[]byte)
+			*ptr = o.([]byte)
 		case int64:
-			o, err := DecodeInteger(b)
+			o, byteLen, err = DecodeInteger(b[bytesDecoded:])
 			if err != nil {
 				return nil, err
 			}
 
-			output[i] = o
+			// get the pointer to the value and set the value
+			ptr := fieldValue.Addr().Interface().(*int64)
+			*ptr = o.(int64)
 		}
+
+		bytesDecoded = bytesDecoded + byteLen
 	}
 
-	return output, nil
+	return t, err
 }

--- a/codec/decode_test.go
+++ b/codec/decode_test.go
@@ -1,0 +1,115 @@
+package codec
+
+import (
+	"bytes"
+	"testing"
+)
+
+type decodeIntTest struct {
+	val    []byte
+	output int64
+}
+
+type decodeByteArrayTest struct {
+	val    []byte
+	output []byte
+}
+
+type decodeBoolTest struct {
+	val    byte
+	output bool
+}
+
+type decodeTupleTest struct {
+	val 	[]byte
+	t  	interface{}
+	output 	interface{}
+}
+
+var decodeIntTests = []decodeIntTest{
+	// compact integers
+	{val: []byte{0x00}, output: int64(0)},
+	{val: []byte{0x04}, output: int64(1)},
+	{val: []byte{0xa8}, output: int64(42)},
+	{val: []byte{0x01, 0x01}, output: int64(64)},
+	{val: []byte{0x15, 0x01}, output: int64(69)},
+	{val: []byte{0xfd, 0xff}, output: int64(16383)},
+	{val: []byte{0x02, 0x00, 0x01, 0x00}, output: int64(16384)},
+	{val: []byte{0xfe, 0xff, 0xff, 0xff}, output: int64(1073741823)},
+	{val: []byte{0x03, 0x00, 0x00, 0x00, 0x40}, output: int64(1073741824)},
+	{val: []byte{0x03, 0xff, 0xff, 0xff, 0xff}, output: int64(1<<32 - 1)},
+	{val: []byte{0x07, 0x00, 0x00, 0x00, 0x00, 0x01}, output: int64(1 << 32)},
+}
+
+var decodeByteArrayTests = []decodeByteArrayTest{
+	// byte arrays
+	{val: []byte{0x04, 0x01}, output: []byte{0x01}},
+	{val: []byte{0x04, 0xff}, output: []byte{0xff}},
+	{val: []byte{0x08, 0x01, 0x01}, output: []byte{0x01, 0x01}},
+	{val: append([]byte{0x01, 0x01}, byteArray(64)...), output: byteArray(64)},
+	{val: append([]byte{0xfd, 0xff}, byteArray(16384)...), output: byteArray(16383)},
+	{val: append([]byte{0x02, 0x00, 0x01, 0x00}, byteArray(16384)...), output: byteArray(16384)},
+	{val: append([]byte{0xfe, 0xff, 0xff, 0xff}, byteArray(1073741823)...), output: byteArray(1073741823)},
+	//{val: append([]byte{0x03, 0x00, 0x00, 0x00, 0x40}, byteArray(1073741824)...), output: byteArray(1073741824)},
+}
+
+var decodeBoolTests = []decodeBoolTest{
+	{val: 0x01, output: true},
+	{val: 0x00, output: false},
+}
+
+var decodeTupleTests = []decodeTupleTest{
+	{val: []byte{0x04, 0x01, 0x08}, t: struct{Foo []byte; Bar int64}{}, output: struct{Foo []byte; Bar int64}{[]byte{0x01}, 2}},
+}
+
+func TestDecodeInts(t *testing.T) {
+	for _, test := range decodeIntTests {
+		output, err := DecodeInteger(test.val)
+		if err != nil {
+			t.Error(err)
+		} else if output != test.output {
+			t.Errorf("Fail: got %d expected %d", output, test.output)
+		}
+	}
+}
+
+func TestDecodeByteArrays(t *testing.T) {
+	for _, test := range decodeByteArrayTests {
+		output, err := DecodeByteArray(test.val)
+		if err != nil {
+			t.Error(err)
+		} else if !bytes.Equal(output, test.output) {
+			t.Errorf("Fail: got %d expected %d", len(output), len(test.output))
+		}
+	}
+}
+
+func TestDecodeBool(t *testing.T) {
+	for _, test := range decodeBoolTests {
+		output, err := DecodeBool(test.val)
+		if err != nil {
+			t.Error(err)
+		} else if output != test.output {
+			t.Errorf("Fail: got %t expected %t", output, test.output)
+		}
+	}
+
+	output, err := DecodeBool(0xff)
+	if err == nil {
+		t.Error("did not error for invalid bool")
+	} else if output {
+		t.Errorf("Fail: got %t expected false", output)
+	}
+}
+
+
+func TestDecodeTuples(t *testing.T) {
+	for _, test := range decodeTupleTests {
+		output, err := DecodeTuple(test.val, test.t)
+		if err != nil {
+			t.Error(err)
+		} else if output != test.output {
+			t.Errorf("Fail: got %t expected %t", output, test.output)
+		}
+	}
+}

--- a/codec/decode_test.go
+++ b/codec/decode_test.go
@@ -49,12 +49,12 @@ var decodeByteArrayTests = []decodeByteArrayTest{
 	{val: []byte{0x04, 0x01}, output: []byte{0x01}, bytesDecoded: 2},
 	{val: []byte{0x04, 0xff}, output: []byte{0xff}, bytesDecoded: 2},
 	{val: []byte{0x08, 0x01, 0x01}, output: []byte{0x01, 0x01}, bytesDecoded: 3},
-	{val: append([]byte{0x01, 0x01}, byteArray(64)...), output: byteArray(64)},
-	{val: append([]byte{0xfd, 0xff}, byteArray(16384)...), output: byteArray(16383)},
-	{val: append([]byte{0x02, 0x00, 0x01, 0x00}, byteArray(16384)...), output: byteArray(16384)},
-	{val: append([]byte{0xfe, 0xff, 0xff, 0xff}, byteArray(1073741823)...), output: byteArray(1073741823)},
+	{val: append([]byte{0x01, 0x01}, byteArray(64)...), output: byteArray(64), bytesDecoded: 66},
+	{val: append([]byte{0xfd, 0xff}, byteArray(16383)...), output: byteArray(16383), bytesDecoded: 16385},
+	{val: append([]byte{0x02, 0x00, 0x01, 0x00}, byteArray(16384)...), output: byteArray(16384), bytesDecoded: 16388},
+	{val: append([]byte{0xfe, 0xff, 0xff, 0xff}, byteArray(1073741823)...), output: byteArray(1073741823), bytesDecoded: 1073741827},
 	// Causes CI to crash
-	//{val: append([]byte{0x03, 0x00, 0x00, 0x00, 0x40}, byteArray(1073741824)...), output: byteArray(1073741824)},
+	{val: append([]byte{0x03, 0x00, 0x00, 0x00, 0x40}, byteArray(1073741824)...), output: byteArray(1073741824), bytesDecoded: 1073741829},
 }
 
 var decodeBoolTests = []decodeBoolTest{
@@ -125,11 +125,13 @@ func TestDecodeInts(t *testing.T) {
 
 func TestDecodeByteArrays(t *testing.T) {
 	for _, test := range decodeByteArrayTests {
-		output, _, err := DecodeByteArray(test.val)
+		output, bytesDecoded, err := DecodeByteArray(test.val)
 		if err != nil {
 			t.Error(err)
 		} else if !bytes.Equal(output, test.output) {
 			t.Errorf("Fail: got %d expected %d", len(output), len(test.output))
+		} else if bytesDecoded != test.bytesDecoded {
+			t.Errorf("Fail: got %d bytesDecoded expected %d", bytesDecoded, test.bytesDecoded)
 		}
 	}
 }

--- a/codec/decode_test.go
+++ b/codec/decode_test.go
@@ -7,15 +7,15 @@ import (
 )
 
 type decodeIntTest struct {
-	val    []byte
-	output int64
+	val          []byte
+	output       int64
 	bytesDecoded int64
 }
 
 type decodeByteArrayTest struct {
-	val    []byte
-	output []byte
-	bytesDecoded int64 
+	val          []byte
+	output       []byte
+	bytesDecoded int64
 }
 
 type decodeBoolTest struct {
@@ -24,9 +24,9 @@ type decodeBoolTest struct {
 }
 
 type decodeTupleTest struct {
-	val 	[]byte
-	t  		interface{}
-	output 	interface{}
+	val    []byte
+	t      interface{}
+	output interface{}
 }
 
 var decodeIntTests = []decodeIntTest{
@@ -62,11 +62,51 @@ var decodeBoolTests = []decodeBoolTest{
 }
 
 var decodeTupleTests = []decodeTupleTest{
-	{val: []byte{0x04, 0x01, 0x08}, t: &struct{Foo []byte; Bar int64}{}, output: &struct{Foo []byte; Bar int64}{[]byte{0x01}, 2}},
-	{val: []byte{0x04, 0x01, 0x08}, t: &struct{Foo []byte; Bar int64}{}, output: &struct{Foo []byte; Bar int64}{[]byte{0x01}, 2}},
-	{val: []byte{0x04, 0x01, 0x08}, t: &struct{Foo []byte; Bar int64}{}, output: &struct{Foo []byte; Bar int64}{[]byte{0x01}, 2}},
-	{val: []byte{0x04, 0x01, 0x08}, t: &struct{Foo []byte; Bar int64}{}, output: &struct{Foo []byte; Bar int64}{[]byte{0x01}, 2}},
+	{val: []byte{0x04, 0x01, 0x08}, t: &struct {
+		Foo []byte
+		Bar int64
+	}{}, output: &struct {
+		Foo []byte
+		Bar int64
+	}{[]byte{0x01}, 2}},
 
+	{val: []byte{0x04, 0x01, 0x03, 0xff, 0xff, 0xff, 0xff}, t: &struct {
+		Foo []byte
+		Bar int64
+	}{}, output: &struct {
+		Foo []byte
+		Bar int64
+	}{[]byte{0x01}, int64(1<<32 - 1)}},
+
+	{val: append([]byte{0x04, 0x01, 0x02, 0x00, 0x01, 0x00}, byteArray(16384)...), t: &struct {
+		Foo []byte
+		Bar []byte
+	}{}, output: &struct {
+		Foo []byte
+		Bar []byte
+	}{[]byte{0x01}, byteArray(16384)}},
+
+	{val: []byte{0x04, 0x01, 0xfd, 0xff, 0x07, 0x00, 0x00, 0x00, 0x00, 0x01}, t: &struct {
+		Foo []byte
+		Bar int64
+		Noot int64
+	}{}, output: &struct {
+		Foo []byte
+		Bar int64
+		Noot int64
+	}{[]byte{0x01}, 16383, int64(1 << 32)}},
+
+	{val: []byte{0x04, 0x01, 0xfd, 0xff, 0x01, 0x07, 0x00, 0x00, 0x00, 0x00, 0x01}, t: &struct {
+		Foo []byte
+		Bar int64
+		Bo 	bool
+		Noot int64
+	}{}, output: &struct {
+		Foo []byte
+		Bar int64
+		Bo  bool
+		Noot int64
+	}{[]byte{0x01}, 16383, true, int64(1 << 32)}},
 }
 
 func TestDecodeInts(t *testing.T) {
@@ -110,7 +150,6 @@ func TestDecodeBool(t *testing.T) {
 		t.Errorf("Fail: got %t expected false", output)
 	}
 }
-
 
 func TestDecodeTuples(t *testing.T) {
 	for _, test := range decodeTupleTests {

--- a/codec/decode_test.go
+++ b/codec/decode_test.go
@@ -54,7 +54,7 @@ var decodeByteArrayTests = []decodeByteArrayTest{
 	{val: append([]byte{0x02, 0x00, 0x01, 0x00}, byteArray(16384)...), output: byteArray(16384), bytesDecoded: 16388},
 	{val: append([]byte{0xfe, 0xff, 0xff, 0xff}, byteArray(1073741823)...), output: byteArray(1073741823), bytesDecoded: 1073741827},
 	// Causes CI to crash
-	{val: append([]byte{0x03, 0x00, 0x00, 0x00, 0x40}, byteArray(1073741824)...), output: byteArray(1073741824), bytesDecoded: 1073741829},
+	//{val: append([]byte{0x03, 0x00, 0x00, 0x00, 0x40}, byteArray(1073741824)...), output: byteArray(1073741824), bytesDecoded: 1073741829},
 }
 
 var decodeBoolTests = []decodeBoolTest{

--- a/codec/decode_test.go
+++ b/codec/decode_test.go
@@ -2,17 +2,20 @@ package codec
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 )
 
 type decodeIntTest struct {
 	val    []byte
 	output int64
+	bytesDecoded int64
 }
 
 type decodeByteArrayTest struct {
 	val    []byte
 	output []byte
+	bytesDecoded int64 
 }
 
 type decodeBoolTest struct {
@@ -22,29 +25,29 @@ type decodeBoolTest struct {
 
 type decodeTupleTest struct {
 	val 	[]byte
-	t  	interface{}
+	t  		interface{}
 	output 	interface{}
 }
 
 var decodeIntTests = []decodeIntTest{
 	// compact integers
-	{val: []byte{0x00}, output: int64(0)},
-	{val: []byte{0x04}, output: int64(1)},
-	{val: []byte{0xa8}, output: int64(42)},
-	{val: []byte{0x01, 0x01}, output: int64(64)},
-	{val: []byte{0x15, 0x01}, output: int64(69)},
-	{val: []byte{0xfd, 0xff}, output: int64(16383)},
-	{val: []byte{0x02, 0x00, 0x01, 0x00}, output: int64(16384)},
-	{val: []byte{0xfe, 0xff, 0xff, 0xff}, output: int64(1073741823)},
-	{val: []byte{0x03, 0x00, 0x00, 0x00, 0x40}, output: int64(1073741824)},
-	{val: []byte{0x03, 0xff, 0xff, 0xff, 0xff}, output: int64(1<<32 - 1)},
-	{val: []byte{0x07, 0x00, 0x00, 0x00, 0x00, 0x01}, output: int64(1 << 32)},
+	{val: []byte{0x00}, output: int64(0), bytesDecoded: 1},
+	{val: []byte{0x04}, output: int64(1), bytesDecoded: 1},
+	{val: []byte{0xa8}, output: int64(42), bytesDecoded: 1},
+	{val: []byte{0x01, 0x01}, output: int64(64), bytesDecoded: 2},
+	{val: []byte{0x15, 0x01}, output: int64(69), bytesDecoded: 2},
+	{val: []byte{0xfd, 0xff}, output: int64(16383), bytesDecoded: 2},
+	{val: []byte{0x02, 0x00, 0x01, 0x00}, output: int64(16384), bytesDecoded: 4},
+	{val: []byte{0xfe, 0xff, 0xff, 0xff}, output: int64(1073741823), bytesDecoded: 4},
+	{val: []byte{0x03, 0x00, 0x00, 0x00, 0x40}, output: int64(1073741824), bytesDecoded: 5},
+	{val: []byte{0x03, 0xff, 0xff, 0xff, 0xff}, output: int64(1<<32 - 1), bytesDecoded: 5},
+	{val: []byte{0x07, 0x00, 0x00, 0x00, 0x00, 0x01}, output: int64(1 << 32), bytesDecoded: 6},
 }
 
 var decodeByteArrayTests = []decodeByteArrayTest{
 	// byte arrays
-	{val: []byte{0x04, 0x01}, output: []byte{0x01}},
-	{val: []byte{0x04, 0xff}, output: []byte{0xff}},
+	{val: []byte{0x04, 0x01}, output: []byte{0x01}, bytesDecoded: 2},
+	{val: []byte{0x04, 0xff}, output: []byte{0xff}, bytesDecoded: 2},
 	{val: []byte{0x08, 0x01, 0x01}, output: []byte{0x01, 0x01}},
 	{val: append([]byte{0x01, 0x01}, byteArray(64)...), output: byteArray(64)},
 	{val: append([]byte{0xfd, 0xff}, byteArray(16384)...), output: byteArray(16383)},
@@ -59,23 +62,25 @@ var decodeBoolTests = []decodeBoolTest{
 }
 
 var decodeTupleTests = []decodeTupleTest{
-	{val: []byte{0x04, 0x01, 0x08}, t: struct{Foo []byte; Bar int64}{}, output: struct{Foo []byte; Bar int64}{[]byte{0x01}, 2}},
+	{val: []byte{0x04, 0x01, 0x08}, t: &struct{Foo []byte; Bar int64}{}, output: &struct{Foo []byte; Bar int64}{[]byte{0x01}, 2}},
 }
 
 func TestDecodeInts(t *testing.T) {
 	for _, test := range decodeIntTests {
-		output, err := DecodeInteger(test.val)
+		output, bytesDecoded, err := DecodeInteger(test.val)
 		if err != nil {
 			t.Error(err)
 		} else if output != test.output {
 			t.Errorf("Fail: got %d expected %d", output, test.output)
+		} else if bytesDecoded != test.bytesDecoded {
+			t.Errorf("Fail: got %d bytesDecoded expected %d", bytesDecoded, test.bytesDecoded)
 		}
 	}
 }
 
 func TestDecodeByteArrays(t *testing.T) {
 	for _, test := range decodeByteArrayTests {
-		output, err := DecodeByteArray(test.val)
+		output, _, err := DecodeByteArray(test.val)
 		if err != nil {
 			t.Error(err)
 		} else if !bytes.Equal(output, test.output) {
@@ -108,7 +113,7 @@ func TestDecodeTuples(t *testing.T) {
 		output, err := DecodeTuple(test.val, test.t)
 		if err != nil {
 			t.Error(err)
-		} else if output != test.output {
+		} else if !reflect.DeepEqual(output, test.output) {
 			t.Errorf("Fail: got %t expected %t", output, test.output)
 		}
 	}

--- a/codec/decode_test.go
+++ b/codec/decode_test.go
@@ -63,6 +63,10 @@ var decodeBoolTests = []decodeBoolTest{
 
 var decodeTupleTests = []decodeTupleTest{
 	{val: []byte{0x04, 0x01, 0x08}, t: &struct{Foo []byte; Bar int64}{}, output: &struct{Foo []byte; Bar int64}{[]byte{0x01}, 2}},
+	{val: []byte{0x04, 0x01, 0x08}, t: &struct{Foo []byte; Bar int64}{}, output: &struct{Foo []byte; Bar int64}{[]byte{0x01}, 2}},
+	{val: []byte{0x04, 0x01, 0x08}, t: &struct{Foo []byte; Bar int64}{}, output: &struct{Foo []byte; Bar int64}{[]byte{0x01}, 2}},
+	{val: []byte{0x04, 0x01, 0x08}, t: &struct{Foo []byte; Bar int64}{}, output: &struct{Foo []byte; Bar int64}{[]byte{0x01}, 2}},
+
 }
 
 func TestDecodeInts(t *testing.T) {

--- a/codec/decode_test.go
+++ b/codec/decode_test.go
@@ -87,24 +87,24 @@ var decodeTupleTests = []decodeTupleTest{
 	}{[]byte{0x01}, byteArray(16384)}},
 
 	{val: []byte{0x04, 0x01, 0xfd, 0xff, 0x07, 0x00, 0x00, 0x00, 0x00, 0x01}, t: &struct {
-		Foo []byte
-		Bar int64
+		Foo  []byte
+		Bar  int64
 		Noot int64
 	}{}, output: &struct {
-		Foo []byte
-		Bar int64
+		Foo  []byte
+		Bar  int64
 		Noot int64
 	}{[]byte{0x01}, 16383, int64(1 << 32)}},
 
 	{val: []byte{0x04, 0x01, 0xfd, 0xff, 0x01, 0x07, 0x00, 0x00, 0x00, 0x00, 0x01}, t: &struct {
-		Foo []byte
-		Bar int64
-		Bo 	bool
+		Foo  []byte
+		Bar  int64
+		Bo   bool
 		Noot int64
 	}{}, output: &struct {
-		Foo []byte
-		Bar int64
-		Bo  bool
+		Foo  []byte
+		Bar  int64
+		Bo   bool
 		Noot int64
 	}{[]byte{0x01}, 16383, true, int64(1 << 32)}},
 }

--- a/codec/encode.go
+++ b/codec/encode.go
@@ -3,6 +3,7 @@ package codec
 import (
 	"encoding/binary"
 	"errors"
+	"reflect"
 )
 
 // Encode is the top-level function which performs SCALE encoding of b which may be of type []byte, int16, int32, int64,
@@ -17,8 +18,12 @@ func Encode(b interface{}) ([]byte, error) {
 		return encodeInteger(int(v))
 	case int64:
 		return encodeInteger(int(v))
+	case string:
+		return encodeByteArray([]byte(v))
 	case bool:
 		return encodeBool(v)
+	case interface{}:
+		return encodeTuple(v)
 	default:
 		return nil, errors.New("unsupported type")
 	}
@@ -91,4 +96,26 @@ func encodeBool(l bool) ([]byte, error) {
 		return []byte{0x01}, nil
 	} 
 	return []byte{0x00}, nil
+}
+
+func encodeTuple(t interface{}) ([]byte, error) {
+	v := reflect.ValueOf(t)
+
+	values := make([]interface{}, v.NumField())
+
+	for i := 0; i < v.NumField(); i++ {
+		values[i] = v.Field(i).Interface()
+	}
+
+	o := []byte{}
+	for _, item := range values {
+		encodedItem, err := Encode(item)
+		if err != nil {
+			return nil, err
+		}
+
+		o = append(o, encodedItem...)
+	}
+
+	return o, nil
 }

--- a/codec/encode.go
+++ b/codec/encode.go
@@ -61,7 +61,7 @@ func encodeInteger(i int) ([]byte, error) {
 		o := make([]byte, 4)
 		binary.LittleEndian.PutUint32(o, uint32(i<<2)+2)
 		return o, nil
-	} 
+	}
 
 	// TODO: this case only works for integers between 2**30 and 2**64 due to the fact that Go's integers only hold up
 	// to 2 ** 64. need to implement this case for integers > 2**64 using the big.Int library
@@ -94,7 +94,7 @@ func encodeInteger(i int) ([]byte, error) {
 func encodeBool(l bool) ([]byte, error) {
 	if l {
 		return []byte{0x01}, nil
-	} 
+	}
 	return []byte{0x00}, nil
 }
 

--- a/codec/encode_test.go
+++ b/codec/encode_test.go
@@ -10,10 +10,6 @@ type encodeTest struct {
 	output []byte
 }
 
-type Noot struct {
-	Noodle 	int64
-}
-
 var encodeTests = []encodeTest{
 	// compact integers
 	{val: int64(0), output: []byte{0x00}},
@@ -40,10 +36,23 @@ var encodeTests = []encodeTest{
 	{val: false, output: []byte{0x00}},
 
 	// structs
-	{val: struct{Foo []byte; Bar int64}{[]byte{0x01}, 2}, output: []byte{0x04, 0x01, 0x08}},
-	{val: struct{Foo []byte; Bar int64; Ok bool}{[]byte{0x01}, 2, true}, output: []byte{0x04, 0x01, 0x08, 0x01}},
-	{val: struct{Foo int64; Bar []byte}{int64(16384), []byte{0xff}}, output: []byte{0x02, 0x00, 0x01, 0x00, 0x04, 0xff}},
-	{val: struct{Foo int64; Bar []byte}{int64(1073741824), byteArray(64)}, output: append([]byte{0x03, 0x00, 0x00, 0x00, 0x40, 0x01, 0x01}, byteArray(64)...)},
+	{val: struct {
+		Foo []byte
+		Bar int64
+	}{[]byte{0x01}, 2}, output: []byte{0x04, 0x01, 0x08}},
+	{val: struct {
+		Foo []byte
+		Bar int64
+		Ok  bool
+	}{[]byte{0x01}, 2, true}, output: []byte{0x04, 0x01, 0x08, 0x01}},
+	{val: struct {
+		Foo int64
+		Bar []byte
+	}{int64(16384), []byte{0xff}}, output: []byte{0x02, 0x00, 0x01, 0x00, 0x04, 0xff}},
+	{val: struct {
+		Foo int64
+		Bar []byte
+	}{int64(1073741824), byteArray(64)}, output: append([]byte{0x03, 0x00, 0x00, 0x00, 0x40, 0x01, 0x01}, byteArray(64)...)},
 	//{val: struct{Foo []byte; Bar Noot}{[]byte{0x01}, {1}}, output: []byte{0x04, 0x01, 0x04}},
 }
 

--- a/codec/encode_test.go
+++ b/codec/encode_test.go
@@ -53,7 +53,6 @@ var encodeTests = []encodeTest{
 		Foo int64
 		Bar []byte
 	}{int64(1073741824), byteArray(64)}, output: append([]byte{0x03, 0x00, 0x00, 0x00, 0x40, 0x01, 0x01}, byteArray(64)...)},
-	//{val: struct{Foo []byte; Bar Noot}{[]byte{0x01}, {1}}, output: []byte{0x04, 0x01, 0x04}},
 }
 
 func TestEncode(t *testing.T) {

--- a/codec/encode_test.go
+++ b/codec/encode_test.go
@@ -10,6 +10,10 @@ type encodeTest struct {
 	output []byte
 }
 
+type Noot struct {
+	Noodle 	int64
+}
+
 var encodeTests = []encodeTest{
 	// compact integers
 	{val: int64(0), output: []byte{0x00}},
@@ -34,6 +38,13 @@ var encodeTests = []encodeTest{
 	// booleans
 	{val: true, output: []byte{0x01}},
 	{val: false, output: []byte{0x00}},
+
+	// structs
+	{val: struct{Foo []byte; Bar int64}{[]byte{0x01}, 2}, output: []byte{0x04, 0x01, 0x08}},
+	{val: struct{Foo []byte; Bar int64; Ok bool}{[]byte{0x01}, 2, true}, output: []byte{0x04, 0x01, 0x08, 0x01}},
+	{val: struct{Foo int64; Bar []byte}{int64(16384), []byte{0xff}}, output: []byte{0x02, 0x00, 0x01, 0x00, 0x04, 0xff}},
+	{val: struct{Foo int64; Bar []byte}{int64(1073741824), byteArray(64)}, output: append([]byte{0x03, 0x00, 0x00, 0x00, 0x40, 0x01, 0x01}, byteArray(64)...)},
+	//{val: struct{Foo []byte; Bar Noot}{[]byte{0x01}, {1}}, output: []byte{0x04, 0x01, 0x04}},
 }
 
 func TestEncode(t *testing.T) {

--- a/codec/helpers_test.go
+++ b/codec/helpers_test.go
@@ -1,7 +1,7 @@
 package codec
 
 // make byte array with length specified; used to test byte array encoding
-func byteArray(length int) ([]byte) {
+func byteArray(length int) []byte {
 	b := make([]byte, length)
 	for i := 0; i < length; i++ {
 		b[i] = 0xff


### PR DESCRIPTION
## Changes
Added encoding and decoding of tuples (ie. structs).  Also, in DecodeByteArray and DecodeInteger, I now return another parameter `bytesDecoded` which is the number of the input bytes that were decoded.  I need this to keep track of how many bytes we've decoded so far in DecodeTuple, since an encoded tuple is the concatenation of all the fields, encoded, inside the struct.   As well as adding more comments.  

## Tests:
```
go test ./codec/...
```